### PR TITLE
Ensure GHC 8.4 is used by default

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.11
+resolver: lts-12.17
 packages:
 - .
 


### PR DESCRIPTION
Prevents the first issue in https://github.com/Eelis/cxxdraft-htmlgen/issues/66.