### PR TITLE
Override hard-coded color in \opt for dark mode

### DIFF
--- a/14882.css
+++ b/14882.css
@@ -542,6 +542,8 @@ table.enumerate td:first-child {
         color: #b0b0b0;
     }
 
+    span.mjx-mstyle { color: #b0b0b0 !important }
+
     a { color: #549df2; }
 
     span.phantom { color: #171717; }


### PR DESCRIPTION
`\opt` generates [something like](http://eel.is/c++draft/lex.fcon#nt:decimal-floating-point-literal) (linebreaks added for readability)

```html
<span class="mjx-mstyle" style="font-size: 113.1%; color: black;">
<span class="mjx-mrow" style="font-size: 88.4%;">
<span class="mjx-mi">
<span class="mjx-char MJXc-TeX-main-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">
o
</span>
</span>
</span>
</span>
<span class="mjx-mi">
<span class="mjx-char MJXc-TeX-main-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">
p
</span>
</span>
<span class="mjx-mi">
<span class="mjx-char MJXc-TeX-main-I" style="padding-top: 0.372em; padding-bottom: 0.298em;">
t
</span>
</span>
```

so the `o` remains black even in dark mode. 